### PR TITLE
UIP-008: Change Arbitrum dripping schedule and update half decay point of the Comptroller

### DIFF
--- a/abis/Comptroller.json
+++ b/abis/Comptroller.json
@@ -1,0 +1,810 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "previousAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "AdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "beacon",
+                "type": "address"
+            }
+        ],
+        "name": "BeaconUpgraded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "LogWithdrawRewards",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Unpaused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "Upgraded",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "INIT_INFLATION_INDEX",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "ROLE_ADMIN",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "unionToken_",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "marketRegistry_",
+                "type": "address"
+            }
+        ],
+        "name": "__Comptroller_init",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "admin_",
+                "type": "address"
+            }
+        ],
+        "name": "__Controller_init",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "addAdmin",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "staker",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "lockedStake",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "lastRepay",
+                "type": "uint256"
+            }
+        ],
+        "name": "addFrozenCoinAge",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            }
+        ],
+        "name": "calculateRewards",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "futureBlocks",
+                "type": "uint256"
+            }
+        ],
+        "name": "calculateRewardsByBlocks",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "gInflationIndex",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "gLastUpdatedBlock",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            }
+        ],
+        "name": "getRewardsMultiplier",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "halfDecayPoint",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "effectiveTotalStake",
+                "type": "uint256"
+            }
+        ],
+        "name": "inflationPerBlock",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "isAdmin",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "index",
+                "type": "uint256"
+            }
+        ],
+        "name": "lookup",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "marketRegistry",
+        "outputs": [
+            {
+                "internalType": "contract IMarketRegistry",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "memberRatio",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "nonMemberRatio",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pauseGuardian",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceAdmin",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "setGuardian",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "point",
+                "type": "uint256"
+            }
+        ],
+        "name": "setHalfDecayPoint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unionToken",
+        "outputs": [
+            {
+                "internalType": "contract IERC20Upgradeable",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unpause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "totalStaked",
+                "type": "uint256"
+            }
+        ],
+        "name": "updateTotalStaked",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            }
+        ],
+        "name": "upgradeTo",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "upgradeToAndCall",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "users",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "frozenCoinAge",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "updatedBlock",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "inflationIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "accrued",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            }
+        ],
+        "name": "withdrawRewards",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/proposals/008_arbitrum_drip_update/addresses.js
+++ b/proposals/008_arbitrum_drip_update/addresses.js
@@ -1,0 +1,24 @@
+const addresses = require("../../utils/addresses.js");
+
+Object.keys(addresses).map(networkID => {
+    switch (networkID) {
+        case "31337":
+            // For simulations
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddr: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                arbConnectorAddr: "0x307ED81138cA91637E432DbaBaC6E3A42699032a",
+                arbComptrollerAddr: "0x641DD6258cb3E948121B10ee51594Dc2A8549fe1"
+            });
+            break;
+        case "1":
+            // Mainnet
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddr: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                arbConnectorAddr: "0x307ED81138cA91637E432DbaBaC6E3A42699032a",
+                arbComptrollerAddr: "0x641DD6258cb3E948121B10ee51594Dc2A8549fe1"
+            });
+            break;
+    }
+});
+
+module.exports = addresses;

--- a/proposals/008_arbitrum_drip_update/proposal.js
+++ b/proposals/008_arbitrum_drip_update/proposal.js
@@ -1,0 +1,94 @@
+const {ethers} = require("hardhat");
+const ComptrollerABI = require("../../abis/Comptroller.json");
+const TreasuryABI = require("../../abis/Treasury.json");
+
+const arbProposeParams = require("../../utils/arbProposeParams.js");
+
+async function getProposalParams(addresses) {
+    const {treasuryAddr, arbConnectorAddr, arbComptrollerAddr} = addresses;
+    console.log({treasuryAddr, arbConnectorAddr});
+
+    if (!treasuryAddr || !arbConnectorAddr) {
+        throw new Error("address error");
+    }
+
+    //L1 address
+    const excessFeeRefundAddress = "0x7a0C61EdD8b5c0c5C1437AEb571d7DDbF8022Be4";
+    const callValueRefundAddress = "0x7a0C61EdD8b5c0c5C1437AEb571d7DDbF8022Be4";
+
+    // Update treasury's dripping schedule for Arbitrum
+    const treasury = await ethers.getContractAt(TreasuryABI, treasuryAddr);
+    const latestBlock = await ethers.provider.getBlock("latest");
+    console.log({latestBlock});
+    const dripStart = latestBlock.number; // the current block number
+    const dripRate = ethers.utils.parseEther("1"); // 1 UNION per block
+    const target = arbConnectorAddr;
+    const amount = ethers.utils.parseEther("1296000"); // For 6 months, it's 15,552,000 seconds. Assuming a 12 second block, it'll be 1,296,000 UNION
+    const editScheduleCalldata = treasury.interface.encodeFunctionData(
+        "editSchedule(uint256,uint256,address,uint256)",
+        [dripStart, dripRate, target, amount]
+    );
+
+    // Actions for mainnet
+    let targets = [treasuryAddr],
+        values = ["0"],
+        sigs = ["editSchedule(uint256,uint256,address,uint256)"],
+        calldatas = [
+            ethers.utils.defaultAbiCoder.encode(
+                ["uint256", "uint256", "address", "uint256"],
+                [dripStart, dripRate, target, amount]
+            )
+        ],
+        signedCalldatas = [editScheduleCalldata];
+
+    // Update half decay point
+    const arbComptroller = await ethers.getContractAt(ComptrollerABI, arbComptrollerAddr);
+    const newHalfDecayPoint = "250000";
+    const setHalfDecayPointCalldata = arbComptroller.interface.encodeFunctionData("setHalfDecayPoint(uint256)", [
+        newHalfDecayPoint
+    ]);
+
+    // Actions for Arbitrum
+    const actions = [[["uint256"], [newHalfDecayPoint], arbComptrollerAddr, "0", setHalfDecayPointCalldata]];
+    for (let i = 0; i < actions.length; i++) {
+        const action = actions[i];
+        const {target, value, signature, calldata, signCalldata} = await arbProposeParams(
+            action[0], // types
+            action[1], // params
+            action[2], // target
+            action[3], // values
+            action[4], // calldata
+            excessFeeRefundAddress,
+            callValueRefundAddress
+        );
+        targets.push(target);
+        values.push(value);
+        sigs.push(signature);
+        calldatas.push(calldata);
+        signedCalldatas.push(signCalldata);
+    }
+
+    const msg = `
+UIP-008: Create new drip schedule for Arbitrum
+
+# Abstract
+
+# Motivation
+
+# Specification
+
+# Test Cases
+
+# Implementation
+
+`;
+
+    console.log("Proposal contents");
+    console.log({targets, values, sigs, calldatas, signedCalldatas, msg});
+
+    return {targets, values, sigs, calldatas, signedCalldatas, msg};
+}
+
+module.exports = {
+    getProposalParams
+};

--- a/proposals/008_arbitrum_drip_update/proposal.js
+++ b/proposals/008_arbitrum_drip_update/proposal.js
@@ -69,17 +69,37 @@ async function getProposalParams(addresses) {
     }
 
     const msg = `
-UIP-008: Create new drip schedule for Arbitrum
+UIP-008: Change Arbitrum dripping schedule and update half decay point of the Comptroller
 
 # Abstract
 
+- Drip of 1 UNION for 6 months to the Comptroller on Arbitrum.
+
+- Set half decay point of the Arbitrum Comptroller to 250,000.
+
 # Motivation
+
+As there is not yet a v2 deployment on Arbitrum, we propose to continue a 1 UNION per block drip for the next 6 months to the users of Union on Arbitrum. At the end of the 6 months we can revisit the question, as it seems likely there will either be an Arbitrum v2 deployment or everyone will have migrated to Union v2 on Optimism.
+
+We also propose lowering the half-decay point to 250k. Now that v2 is insured it doesn't make sense to continue to over incentivize TVL on v1. 
 
 # Specification
 
+- Call Treasury.editSchedule() to change the dripping schedule for Arbitrum. Set the dripStart to be the block number when executed, dripRate to be 1 ether, target to be ArbConnector (0x307ED81138cA91637E432DbaBaC6E3A42699032a), and amount to be 1,296,000
+
+- Set the half decay point of the Arbitrum Comptroller to 250,000
+
 # Test Cases
 
+Tests and simulations can be found here: [PR](https://github.com/unioncredit/UIPs/pull/17)
+
 # Implementation
+
+For Mainnet:
+- Call [Treasury](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9).editSchedule() to update the dripping schedule for the Arbitrum.
+
+For Arbitrum
+- Call [Comptroller](https://arbiscan.io/address/0x641DD6258cb3E948121B10ee51594Dc2A8549fe1).setHalfDecayPoint("250000") to set the half decay point to 250,000.
 
 `;
 

--- a/proposals/008_arbitrum_drip_update/submitProposal.js
+++ b/proposals/008_arbitrum_drip_update/submitProposal.js
@@ -1,0 +1,46 @@
+const {ethers, getChainId, getNamedAccounts} = require("hardhat");
+
+(async () => {
+    const {deployer} = await getNamedAccounts();
+    const {getProposalParams} = require(`./proposal.js`);
+    const chainId = await getChainId();
+    console.log({chainId});
+    const addresses = require(`./addresses.js`)[await getChainId()];
+    console.log({addresses});
+
+    const UnionGovernorABI = require("../../abis/UnionGovernor.json");
+    const governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+    console.log({governor: governor.address});
+
+    const latestProposalId = await governor.latestProposalIds(deployer);
+    if (latestProposalId != 0) {
+        const proposersLatestProposalState = await governor.state(latestProposalId);
+        if (proposersLatestProposalState == 1) {
+            throw new Error("Proposer already has an active proposal");
+        } else if (proposersLatestProposalState == 0) {
+            throw new Error("Proposer already has a pending proposal");
+        }
+    }
+
+    const {targets, values, sigs, calldatas, signedCalldatas, msg} = await getProposalParams(addresses);
+
+    let myBuffer = [];
+    let buffer = new Buffer.from(msg);
+
+    for (let i = 0; i < buffer.length; i++) {
+        myBuffer.push(buffer[i]);
+    }
+
+    const proposalId = await governor["hashProposal(address[],uint256[],bytes[],bytes32)"](
+        targets,
+        values,
+        signedCalldatas,
+        ethers.utils.keccak256(myBuffer)
+    );
+    const deadline = await governor.proposalSnapshot(proposalId);
+    if (deadline > 0) {
+        throw new Error("Duplicated proposals");
+    }
+
+    await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+})();

--- a/proposals/008_arbitrum_drip_update/test/testL2Execute.js
+++ b/proposals/008_arbitrum_drip_update/test/testL2Execute.js
@@ -1,0 +1,43 @@
+const {ethers, getChainId, network} = require("hardhat");
+require("chai").should();
+const {parseUnits} = ethers.utils;
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+
+let defaultAccount, addresses;
+describe("Update comptroller's half decay point on Arbitrum", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://arb-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 65887100
+                    }
+                }
+            ]
+        });
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        [defaultAccount] = await ethers.getSigners();
+        timelockSigner = await ethers.getSigner(addresses.arbTimelockAddr);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [timelockSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: timelockSigner.address,
+            value: parseUnits("1")
+        });
+    });
+
+    it("Mock execute and validate results on l2", async () => {
+        const comptroller = await ethers.getContractAt(ComptrollerABI, addresses.arbComptrollerAddr);
+        const newHalfDecayPoint = "250000";
+        await comptroller.connect(timelockSigner).setHalfDecayPoint(newHalfDecayPoint);
+        (await comptroller.halfDecayPoint()).should.eq(newHalfDecayPoint);
+    });
+});

--- a/proposals/008_arbitrum_drip_update/test/testProposal.js
+++ b/proposals/008_arbitrum_drip_update/test/testProposal.js
@@ -1,0 +1,107 @@
+const {ethers, deployments, getChainId, network} = require("hardhat");
+const {expect} = require("chai");
+require("chai").should();
+
+const {parseUnits} = ethers.utils;
+const {waitNBlocks, increaseTime} = require("../../../utils");
+const {getProposalParams} = require("../proposal.js");
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+const TreasuryABI = require("../../../abis/Treasury.json");
+
+const unionUser = "0x0fb99055fcdd69b711f6076be07b386aa2718bc6"; //An address with union
+
+let defaultAccount, governor, unionToken, addresses;
+
+const voteProposal = async governor => {
+    let res;
+    const proposalId = await governor.latestProposalIds(defaultAccount.address);
+
+    const votingDelay = await governor.votingDelay();
+    await waitNBlocks(parseInt(votingDelay) + 10);
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("1");
+
+    await governor.castVote(proposalId, 1);
+    const votingPeriod = await governor.votingPeriod();
+    await waitNBlocks(parseInt(votingPeriod));
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("4"); // Vote succeeded
+
+    console.log(`Queueing proposal Id: ${proposalId}`);
+
+    await governor["queue(uint256)"](proposalId);
+
+    await increaseTime(7 * 24 * 60 * 60);
+
+    res = await governor.getActions(proposalId);
+    console.log(res.toString());
+
+    console.log(`Executing proposal Id: ${proposalId}`);
+
+    await governor["execute(uint256)"](proposalId, {
+        value: parseUnits("1")
+    });
+};
+
+describe("Change dripping schedule and update half decay for Arbitrum", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 16695750
+                    }
+                }
+            ]
+        });
+
+        [defaultAccount] = await ethers.getSigners();
+        unionSigner = await ethers.getSigner(unionUser);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [unionSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: unionSigner.address,
+            value: parseUnits("10")
+        });
+
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        const UnionGovernorABI = require("../../../abis/UnionGovernor.json");
+        const UnionTokenABI = require("../../../abis/UnionToken.json");
+
+        governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+        unionToken = await ethers.getContractAt(UnionTokenABI, addresses.unionTokenAddress);
+        await unionToken.connect(unionSigner).delegate(defaultAccount.address);
+    });
+
+    it("Submit proposal", async () => {
+        console.log({addresses});
+
+        const {targets, values, sigs, calldatas, msg} = await getProposalParams(addresses);
+
+        await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+    });
+
+    it("Cast votes", async () => {
+        await voteProposal(governor);
+    });
+
+    it("Validate results", async () => {
+        // can only verify results on Mainnet
+        const treasury = await ethers.getContractAt(TreasuryABI, addresses.treasuryAddr);
+        const schedule = await treasury.tokenSchedules(addresses.arbConnectorAddr);
+        console.log({schedule});
+        schedule["target"].should.eq(addresses.arbConnectorAddr);
+        schedule["dripRate"].should.eq(parseUnits("1"));
+        schedule["amount"].should.eq(parseUnits("1296000"));
+    });
+});

--- a/utils/addresses.js
+++ b/utils/addresses.js
@@ -18,6 +18,7 @@ module.exports = {
     // Use mainnet addresses for hardhat fork simulations
     31337: {
         unionTokenAddress: "0x5Dfe42eEA70a3e6f93EE54eD9C321aF07A85535C",
-        governorAddress: "0xe1b3F07a9032F0d3deDf3E96c395A4Da74130f6e"
+        governorAddress: "0xe1b3F07a9032F0d3deDf3E96c395A4Da74130f6e",
+        arbTimelockAddr: "0xCce4321F377742C4B3FE458B270c2f271d32A5e9"
     }
 };


### PR DESCRIPTION
# Abstract

- Drip of 1 UNION for 6 months to the Comptroller on Arbitrum.

- Set half decay point of the Arbitrum Comptroller to 250,000.

# Motivation

As there is not yet a v2 deployment on Arbitrum, we propose to continue a 1 UNION per block drip for the next 6 months to the users of Union on Arbitrum. At the end of the 6 months we can revisit the question, as it seems likely there will either be an Arbitrum v2 deployment or everyone will have migrated to Union v2 on Optimism.

We also propose lowering the half-decay point to 250k. Now that v2 is insured it doesn't make sense to continue to over incentivize TVL on v1. 

# Specification

- Call Treasury.editSchedule() to change the dripping schedule for Arbitrum. Set the dripStart to be the block number when executed, dripRate to be 1 ether, target to be ArbConnector (0x307ED81138cA91637E432DbaBaC6E3A42699032a), and amount to be 1,296,000

- Set the half decay point of the Arbitrum Comptroller to 250,000

# Test Cases

Tests and simulations can be found here: [PR](https://github.com/unioncredit/UIPs/pull/17)

# Implementation

For Mainnet:
- Call [Treasury](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9).editSchedule() to update the dripping schedule for the Arbitrum.

For Arbitrum
- Call [Comptroller](https://arbiscan.io/address/0x641DD6258cb3E948121B10ee51594Dc2A8549fe1).setHalfDecayPoint("250000") to set the half decay point to 250,000.
