### PR TITLE
UIP-009 Change Optimism reward schedule

### DIFF
--- a/proposals/009_change_optimism_reward_schedule/addresses.js
+++ b/proposals/009_change_optimism_reward_schedule/addresses.js
@@ -1,0 +1,22 @@
+const addresses = require("../../utils/addresses.js");
+
+Object.keys(addresses).map(networkID => {
+    switch (networkID) {
+        case "31337":
+            // For simulations
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddr: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                opConnectorAddr: "0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65"
+            });
+            break;
+        case "1":
+            // Mainnet
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddr: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                opConnectorAddr: "0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65"
+            });
+            break;
+    }
+});
+
+module.exports = addresses;

--- a/proposals/009_change_optimism_reward_schedule/proposal.js
+++ b/proposals/009_change_optimism_reward_schedule/proposal.js
@@ -47,11 +47,11 @@ UIP-009: Change Optimism reward schedule
 
 # Motivation
 
-We propose to continue a 1 UNION per block drip for the next 6 months to the users of Union on Optimism.
+We propose to continue a 1 UNION per block drip for the next 12 months to the users of Union on Optimism.
 
 # Specification
 
-- Call Treasury.editSchedule() to change the dripping schedule for Optimism. Set the dripStart to be the block number when executed, dripRate to be 1 ether, target to be OpConnector (0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65), and amount to be 2628000
+- Call Treasury.editSchedule() to change the dripping schedule for Optimism. Set the dripStart to be the block number when executed, dripRate to be 1 ether, target to be OpConnector ([0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65](https://etherscan.io/address/0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65)), and amount to be 2628000
 
 # Test Cases
 

--- a/proposals/009_change_optimism_reward_schedule/proposal.js
+++ b/proposals/009_change_optimism_reward_schedule/proposal.js
@@ -1,0 +1,75 @@
+const {ethers} = require("hardhat");
+const TreasuryABI = require("../../abis/Treasury.json");
+
+async function getProposalParams(addresses) {
+    const {treasuryAddr, opConnectorAddr} = addresses;
+    console.log({treasuryAddr, opConnectorAddr});
+
+    if (!treasuryAddr || !opConnectorAddr) {
+        throw new Error("address error");
+    }
+
+    //L1 address
+    const excessFeeRefundAddress = "0x7a0C61EdD8b5c0c5C1437AEb571d7DDbF8022Be4";
+    const callValueRefundAddress = "0x7a0C61EdD8b5c0c5C1437AEb571d7DDbF8022Be4";
+
+    // Update treasury's dripping schedule for Optimism
+    const treasury = await ethers.getContractAt(TreasuryABI, treasuryAddr);
+    const latestBlock = await ethers.provider.getBlock("latest");
+    console.log({latestBlock});
+    const dripStart = latestBlock.number; // the current block number
+    const dripRate = ethers.utils.parseEther("1"); // 1 UNION per block
+    const target = opConnectorAddr;
+    const amount = ethers.utils.parseEther("2628000"); // For 12 months, it's 31,536,000 seconds. Assuming a 12 second block, it'll be 2,628,000 UNION
+    const editScheduleCalldata = treasury.interface.encodeFunctionData(
+        "editSchedule(uint256,uint256,address,uint256)",
+        [dripStart, dripRate, target, amount]
+    );
+
+    // Actions for mainnet
+    let targets = [treasuryAddr],
+        values = ["0"],
+        sigs = ["editSchedule(uint256,uint256,address,uint256)"],
+        calldatas = [
+            ethers.utils.defaultAbiCoder.encode(
+                ["uint256", "uint256", "address", "uint256"],
+                [dripStart, dripRate, target, amount]
+            )
+        ],
+        signedCalldatas = [editScheduleCalldata];
+
+    const msg = `
+UIP-009: Change Optimism reward schedule
+
+# Abstract
+
+- Change Optimism drip schedule to 1 UNION for 12 months
+
+# Motivation
+
+We propose to continue a 1 UNION per block drip for the next 6 months to the users of Union on Optimism.
+
+# Specification
+
+- Call Treasury.editSchedule() to change the dripping schedule for Optimism. Set the dripStart to be the block number when executed, dripRate to be 1 ether, target to be OpConnector (0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65), and amount to be 2628000
+
+# Test Cases
+
+Tests and simulations can be found here: [PR](https://github.com/unioncredit/UIPs/pull/18)
+
+# Implementation
+
+For Mainnet:
+- Call [Treasury](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9).editSchedule() to update the dripping schedule for the Optimism.
+
+`;
+
+    console.log("Proposal contents");
+    console.log({targets, values, sigs, calldatas, signedCalldatas, msg});
+
+    return {targets, values, sigs, calldatas, signedCalldatas, msg};
+}
+
+module.exports = {
+    getProposalParams
+};

--- a/proposals/009_change_optimism_reward_schedule/submitProposal.js
+++ b/proposals/009_change_optimism_reward_schedule/submitProposal.js
@@ -1,0 +1,46 @@
+const {ethers, getChainId, getNamedAccounts} = require("hardhat");
+
+(async () => {
+    const {deployer} = await getNamedAccounts();
+    const {getProposalParams} = require(`./proposal.js`);
+    const chainId = await getChainId();
+    console.log({chainId});
+    const addresses = require(`./addresses.js`)[await getChainId()];
+    console.log({addresses});
+
+    const UnionGovernorABI = require("../../abis/UnionGovernor.json");
+    const governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+    console.log({governor: governor.address});
+
+    const latestProposalId = await governor.latestProposalIds(deployer);
+    if (latestProposalId != 0) {
+        const proposersLatestProposalState = await governor.state(latestProposalId);
+        if (proposersLatestProposalState == 1) {
+            throw new Error("Proposer already has an active proposal");
+        } else if (proposersLatestProposalState == 0) {
+            throw new Error("Proposer already has a pending proposal");
+        }
+    }
+
+    const {targets, values, sigs, calldatas, signedCalldatas, msg} = await getProposalParams(addresses);
+
+    let myBuffer = [];
+    let buffer = new Buffer.from(msg);
+
+    for (let i = 0; i < buffer.length; i++) {
+        myBuffer.push(buffer[i]);
+    }
+
+    const proposalId = await governor["hashProposal(address[],uint256[],bytes[],bytes32)"](
+        targets,
+        values,
+        signedCalldatas,
+        ethers.utils.keccak256(myBuffer)
+    );
+    const deadline = await governor.proposalSnapshot(proposalId);
+    if (deadline > 0) {
+        throw new Error("Duplicated proposals");
+    }
+
+    await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+})();

--- a/proposals/009_change_optimism_reward_schedule/test/testProposal.js
+++ b/proposals/009_change_optimism_reward_schedule/test/testProposal.js
@@ -1,0 +1,104 @@
+const {ethers, getChainId, network} = require("hardhat");
+require("chai").should();
+
+const {parseUnits} = ethers.utils;
+const {waitNBlocks, increaseTime} = require("../../../utils");
+const {getProposalParams} = require("../proposal.js");
+const TreasuryABI = require("../../../abis/Treasury.json");
+
+const unionUser = "0x0fb99055fcdd69b711f6076be07b386aa2718bc6"; //An address with union
+
+let defaultAccount, governor, unionToken, addresses;
+
+const voteProposal = async governor => {
+    let res;
+    const proposalId = await governor.latestProposalIds(defaultAccount.address);
+
+    const votingDelay = await governor.votingDelay();
+    await waitNBlocks(parseInt(votingDelay) + 10);
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("1");
+
+    await governor.castVote(proposalId, 1);
+    const votingPeriod = await governor.votingPeriod();
+    await waitNBlocks(parseInt(votingPeriod));
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("4"); // Vote succeeded
+
+    console.log(`Queueing proposal Id: ${proposalId}`);
+
+    await governor["queue(uint256)"](proposalId);
+
+    await increaseTime(7 * 24 * 60 * 60);
+
+    res = await governor.getActions(proposalId);
+    console.log(res.toString());
+
+    console.log(`Executing proposal Id: ${proposalId}`);
+
+    await governor["execute(uint256)"](proposalId, {
+        value: parseUnits("1")
+    });
+};
+
+describe("Change Optimism reward schedule", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 17186445
+                    }
+                }
+            ]
+        });
+
+        [defaultAccount] = await ethers.getSigners();
+        unionSigner = await ethers.getSigner(unionUser);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [unionSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: unionSigner.address,
+            value: parseUnits("10")
+        });
+
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        const UnionGovernorABI = require("../../../abis/UnionGovernor.json");
+        const UnionTokenABI = require("../../../abis/UnionToken.json");
+
+        governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+        unionToken = await ethers.getContractAt(UnionTokenABI, addresses.unionTokenAddress);
+        await unionToken.connect(unionSigner).delegate(defaultAccount.address);
+    });
+
+    it("Submit proposal", async () => {
+        console.log({addresses});
+
+        const {targets, values, sigs, calldatas, msg} = await getProposalParams(addresses);
+
+        await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+    });
+
+    it("Cast votes", async () => {
+        await voteProposal(governor);
+    });
+
+    it("Validate results", async () => {
+        const treasury = await ethers.getContractAt(TreasuryABI, addresses.treasuryAddr);
+        const schedule = await treasury.tokenSchedules(addresses.opConnectorAddr);
+        console.log({schedule});
+        schedule["target"].should.eq(addresses.opConnectorAddr);
+        schedule["dripRate"].should.eq(parseUnits("1"));
+        schedule["amount"].should.eq(parseUnits("2628000"));
+    });
+});


### PR DESCRIPTION
# Abstract

- Change Optimism drip schedule to 1 UNION for 12 months

# Motivation

We propose to continue a 1 UNION per block drip for the next 12 months to the users of Union on Optimism.

# Specification

- Call Treasury.editSchedule() to change the dripping schedule for Optimism. Set the dripStart to be the block number when executed, dripRate to be 1 ether, target to be OpConnector ([0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65](https://etherscan.io/address/0xF5690129Bf7AD35358Eb2304f4F5B10E0a9B9d65)), and amount to be 2628000

# Test Cases

Tests and simulations can be found here: [PR](https://github.com/unioncredit/UIPs/pull/18)

# Implementation

For Mainnet:
- Call [Treasury](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9).editSchedule() to update the dripping schedule for the Optimism.
