### PR TITLE
UIP-012 Update Arbitrum Dripping Schedule

### DIFF
--- a/proposals/012_send_union_to_arb/addresses.js
+++ b/proposals/012_send_union_to_arb/addresses.js
@@ -1,0 +1,20 @@
+const addresses = require("../../utils/addresses.js");
+
+Object.keys(addresses).map(networkID => {
+    switch (networkID) {
+        case "1":
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddress: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                arbConnectorAddress: "0x307ED81138cA91637E432DbaBaC6E3A42699032a"
+            });
+            break;
+        case "31337":
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddress: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                arbConnectorAddress: "0x307ED81138cA91637E432DbaBaC6E3A42699032a"
+            });
+            break;
+    }
+});
+
+module.exports = addresses;

--- a/proposals/012_send_union_to_arb/proposal.js
+++ b/proposals/012_send_union_to_arb/proposal.js
@@ -1,0 +1,59 @@
+const {ethers} = require("hardhat");
+
+async function getProposalParams({treasuryAddress, arbConnectorAddress}) {
+    if (!treasuryAddress || !arbConnectorAddress) {
+        throw new Error("address error");
+    }
+
+    const parseUnits = ethers.utils.parseUnits;
+
+    const targets = [treasuryAddress];
+    const values = ["0"];
+    const sigs = ["editSchedule(uint256,uint256,address,uint256)"];
+    const params = [
+        "15185500", // drip start block
+        parseUnits("1"), // drip rate, in wei
+        arbConnectorAddress, // target address
+        parseUnits("3696000") // 1 union per block for 1 year + dripped
+    ];
+
+    const calldatas = [ethers.utils.defaultAbiCoder.encode(["uint256", "uint256", "address", "uint256"], params)];
+
+    const msg = `
+    UIP-012 Update Arbitrum Dripping Schedule
+
+    # Abstract
+    
+    Update Arbitrum dripping schedule to send another 1,296,000 UNION tokens to Arbitrum.
+    
+    # Motivation
+    
+    This proposal aims to resolve the issue identified in UIP-008, which was intended to update the Union dripping schedule for Arbitrum. The problem with UIP-008 was that it proposed dripping a total of 1,296,000 UNION to Arbitrum. However, while updating Arbitrum's existing dripping schedule, UIP-008 mistakenly set the total dripping amount to 1,296,000 without accounting for the amount previously dripped. This error caused the Arbitrum dripping to stop, as the previous dripped amount was already greater than the newly proposed amount. To rectify this, we propose changing the total dripping amount to the sum of the previously dripped amount (2,400,000) and the newly proposed amount (1,296,000), bringing the total to 3,696,000.
+    
+    # Specification
+    
+    - Invoke the Treasury.editSchedule() function to modify the dripping schedule for Arbitrum. Set dripStart to the block number at which UIP-008 was executed. The dripRate should be set to 1 UNION per block. Specify the target as the ArbConnector (address: 0x307ED81138cA91637E432DbaBaC6E3A42699032a). Set the total dripping amount to be 3,696,000 UNION.
+    
+    # Test Cases
+    
+    Tests and simulations can be found here: PR
+    
+    # Implementation
+    
+    Call Treasury.editSchedule() to update the dripping schedule for the Arbitrum.
+`;
+    const TreasuryABI = require("../../abis/Treasury.json");
+    const iface = new ethers.utils.Interface(TreasuryABI);
+    const signedCalldatas = [];
+
+    signedCalldatas.push(iface.encodeFunctionData(sigs[0], params));
+
+    console.log("Proposal contents");
+    console.log({targets, values, sigs, calldatas, signedCalldatas, msg});
+
+    return {targets, values, sigs, calldatas, signedCalldatas, msg};
+}
+
+module.exports = {
+    getProposalParams
+};

--- a/proposals/012_send_union_to_arb/submitProposal.js
+++ b/proposals/012_send_union_to_arb/submitProposal.js
@@ -1,0 +1,49 @@
+const {ethers, getChainId, getNamedAccounts} = require("hardhat");
+
+(async () => {
+    const {deployer} = await getNamedAccounts();
+    const {getProposalParams} = require(`./proposal.js`);
+    const chainId = await getChainId();
+    const {governorAddress, treasuryAddress, arbConnectorAddress} = require(`./addresses.js`)[chainId];
+    console.log({governorAddress, treasuryAddress, arbConnectorAddress});
+
+    const UnionGovernorABI = require("../../abis/UnionGovernor.json");
+    const governor = await ethers.getContractAt(UnionGovernorABI, governorAddress);
+    console.log({governor: governor.address});
+
+    const latestProposalId = await governor.latestProposalIds(deployer);
+    if (latestProposalId != 0) {
+        const proposersLatestProposalState = await governor.state(latestProposalId);
+        if (proposersLatestProposalState == 1) {
+            throw new Error("Proposer already has an active proposal");
+        } else if (proposersLatestProposalState == 0) {
+            throw new Error("Proposer already has a pending proposal");
+        }
+    }
+
+    const {targets, values, sigs, calldatas, signedCalldatas, msg} = await getProposalParams({
+        treasuryAddress,
+        arbConnectorAddress
+    });
+
+    const keccak256 = ethers.utils.keccak256;
+    let myBuffer = [];
+    let buffer = new Buffer.from(msg);
+
+    for (let i = 0; i < buffer.length; i++) {
+        myBuffer.push(buffer[i]);
+    }
+
+    const proposalId = await governor["hashProposal(address[],uint256[],bytes[],bytes32)"](
+        targets,
+        values,
+        signedCalldatas,
+        keccak256(myBuffer)
+    );
+    const deadline = await governor.proposalSnapshot(proposalId);
+    if (deadline > 0) {
+        throw new Error("Duplicated proposals");
+    }
+
+    await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+})();

--- a/proposals/012_send_union_to_arb/test/testProposal.js
+++ b/proposals/012_send_union_to_arb/test/testProposal.js
@@ -1,0 +1,115 @@
+const {ethers, deployments, getChainId, network} = require("hardhat");
+const {expect} = require("chai");
+require("chai").should();
+
+const {parseUnits} = ethers.utils;
+const {waitNBlocks, increaseTime} = require("../../../utils");
+const {getProposalParams} = require("../proposal.js");
+const UnionGovernorABI = require("../../../abis/UnionGovernor.json");
+const UnionTokenABI = require("../../../abis/UnionToken.json");
+const TreasuryABI = require("../../../abis/Treasury.json");
+
+const unionUser = "0x0fb99055fcdd69b711f6076be07b386aa2718bc6"; //An address with union
+
+let defaultAccount, governor, unionToken, treasury, arbConnectorAddress;
+
+const voteProposal = async governor => {
+    let res;
+    const proposalId = await governor.latestProposalIds(defaultAccount.address);
+
+    const votingDelay = await governor.votingDelay();
+    await waitNBlocks(parseInt(votingDelay) + 10);
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("1");
+
+    await governor.castVote(proposalId, 1);
+    const votingPeriod = await governor.votingPeriod();
+    await waitNBlocks(parseInt(votingPeriod));
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("4");
+
+    console.log(`Queueing proposal Id: ${proposalId}`);
+
+    await governor["queue(uint256)"](proposalId);
+
+    await increaseTime(7 * 24 * 60 * 60);
+
+    res = await governor.getActions(proposalId);
+    console.log(res.toString());
+
+    console.log(`Executing proposal Id: ${proposalId}`);
+
+    await governor["execute(uint256)"](proposalId);
+};
+
+describe("Drip UNION tokens to Arbitrum", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://eth-mainnet.alchemyapi.io/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 18881500
+                    }
+                }
+            ]
+        });
+        [defaultAccount] = await ethers.getSigners();
+        unionSigner = await ethers.getSigner(unionUser);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [unionSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: unionSigner.address,
+            value: parseUnits("10")
+        });
+
+        const {
+            governorAddress,
+            unionTokenAddress,
+            treasuryAddress,
+            arbConnectorAddress: _arbConnectorAddress
+        } = require(`../addresses.js`)[await getChainId()];
+        arbConnectorAddress = _arbConnectorAddress;
+        console.log({governorAddress, unionTokenAddress, treasuryAddress, arbConnectorAddress});
+
+        governor = await ethers.getContractAt(UnionGovernorABI, governorAddress);
+        unionToken = await ethers.getContractAt(UnionTokenABI, unionTokenAddress);
+        await unionToken.connect(unionSigner).delegate(defaultAccount.address);
+
+        treasury = await ethers.getContractAt(TreasuryABI, treasuryAddress);
+    });
+
+    it("Submit proposal", async () => {
+        const {targets, values, sigs, calldatas, msg} = await getProposalParams({
+            treasuryAddress: treasury.address,
+            arbConnectorAddress
+        });
+
+        await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+    });
+
+    it("Cast votes", async () => {
+        await voteProposal(governor);
+    });
+
+    it("Validate results", async () => {
+        const schedule = await treasury.tokenSchedules(arbConnectorAddress);
+        console.log({schedule});
+        schedule["target"].should.eq(arbConnectorAddress);
+        schedule["dripRate"].should.eq(parseUnits("1"));
+        schedule["amount"].should.eq(parseUnits("3696000"));
+
+        const prevBalance = await unionToken.balanceOf(arbConnectorAddress);
+        await treasury.drip(arbConnectorAddress);
+        const newBalance = await unionToken.balanceOf(arbConnectorAddress);
+        newBalance.should.eq(prevBalance.add(parseUnits("1296000")));
+    });
+});


### PR DESCRIPTION
# Abstract
    
Update Arbitrum dripping schedule to send another 1,296,000 UNION tokens to Arbitrum.
    
# Motivation
    
This proposal aims to resolve the issue identified in UIP-008, which was intended to update the Union dripping schedule for Arbitrum. The problem with UIP-008 was that it proposed dripping a total of 1,296,000 UNION to Arbitrum. However, while updating Arbitrum's existing dripping schedule, UIP-008 mistakenly set the total dripping amount to 1,296,000 without accounting for the amount previously dripped. This error caused the Arbitrum dripping to stop, as the previous dripped amount was already greater than the newly proposed amount. To rectify this, we propose changing the total dripping amount to the sum of the previously dripped amount (2,400,000) and the newly proposed amount (1,296,000), bringing the total to 3,696,000.

# Specification
    
- Invoke the Treasury.editSchedule() function to modify the dripping schedule for Arbitrum. Set dripStart to the block number at which UIP-008 was executed. The dripRate should be set to 1 UNION per block. Specify the target as the ArbConnector (address: 0x307ED81138cA91637E432DbaBaC6E3A42699032a). Set the total dripping amount to be 3,696,000 UNION.
    
# Test Cases
    
Tests and simulations can be found here: PR
    
# Implementation
    
Call Treasury.editSchedule() to update the dripping schedule for the Arbitrum.