### PR TITLE
UIP-016: Update Half Decay Point and Max Stake Parameters

### DIFF
--- a/proposals/016_update_decay_and_max_stake/addresses.js
+++ b/proposals/016_update_decay_and_max_stake/addresses.js
@@ -1,0 +1,28 @@
+const addresses = require("../../utils/addresses.js");
+
+Object.keys(addresses).map(networkID => {
+    switch (networkID) {
+        case "1":
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                comptrollerAddr: "0x216dE4089dCdD7B95BC34BdCe809669C788a9A5d",
+                arbComptrollerAddr: "0x641DD6258cb3E948121B10ee51594Dc2A8549fe1",
+                opComptrollerAddr: "0x06a31efa04453C5F9C0A711Cdb96075308C9d6E3",
+                opUserManagerAddr: "0x8E195D65b9932185Fcc76dB5144534e0f3597628",
+                opOwnerAddr: "0x946A2C918F3D928B918C01D813644f27Bcd29D96",
+                optimismBridgeAddress: "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1"
+            });
+            break;
+        case "31337":
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                comptrollerAddr: "0x216dE4089dCdD7B95BC34BdCe809669C788a9A5d",
+                arbComptrollerAddr: "0x641DD6258cb3E948121B10ee51594Dc2A8549fe1",
+                opComptrollerAddr: "0x06a31efa04453C5F9C0A711Cdb96075308C9d6E3",
+                opUserManagerAddr: "0x8E195D65b9932185Fcc76dB5144534e0f3597628",
+                opOwnerAddr: "0x946A2C918F3D928B918C01D813644f27Bcd29D96",
+                optimismBridgeAddress: "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1"
+            });
+            break;
+    }
+});
+
+module.exports = addresses;

--- a/proposals/016_update_decay_and_max_stake/proposal.js
+++ b/proposals/016_update_decay_and_max_stake/proposal.js
@@ -83,7 +83,7 @@ async function getProposalParams(addresses) {
     );
 
     // set max stake
-    const maxStakeAmount = "25000000000000000000000";
+    const maxStakeAmount = "50000000000000000000000";
     const opSetMaxStakeAmountCalldata = iface.encodeFunctionData("setMaxStakeAmount(uint96)", [maxStakeAmount]);
     const executeData = opOwner.interface.encodeFunctionData("execute(address,uint256,bytes)", [
         opUserManagerAddr,

--- a/proposals/016_update_decay_and_max_stake/proposal.js
+++ b/proposals/016_update_decay_and_max_stake/proposal.js
@@ -1,0 +1,152 @@
+const {ethers} = require("hardhat");
+const {Interface} = require("ethers/lib/utils");
+const OpOwnerABI = require("../../abis/OpOwner.json");
+const ComptrollerABI = require("../../abis/Comptroller.json");
+const arbProposeParams = require("../../utils/arbProposeParams.js");
+
+async function getProposalParams(addresses) {
+    const {
+        opOwnerAddr,
+        comptrollerAddr,
+        arbComptrollerAddr,
+        opComptrollerAddr,
+        opUserManagerAddr,
+        optimismBridgeAddress
+    } = addresses;
+
+    const comptroller = await ethers.getContractAt(ComptrollerABI, comptrollerAddr);
+    const ethHalfdecayPoint = 10000;
+    const setHalfDecayPointCalldata = comptroller.interface.encodeFunctionData("setHalfDecayPoint(uint256)", [
+        ethHalfdecayPoint
+    ]);
+
+    const iface = new Interface([
+        "function sendMessage(address,bytes,uint32) external",
+        "function setHalfDecayPoint(uint256) external",
+        "function setMaxStakeAmount(uint96) external"
+    ]);
+    // Actions for mainnet
+    let targets = [comptrollerAddr],
+        values = ["0"],
+        sigs = ["setHalfDecayPoint(uint256)"],
+        calldatas = [ethers.utils.defaultAbiCoder.encode(["uint256"], [ethHalfdecayPoint])],
+        signedCalldatas = [setHalfDecayPointCalldata];
+
+    // Actions for Arbitrum
+    const excessFeeRefundAddress = "0x7a0C61EdD8b5c0c5C1437AEb571d7DDbF8022Be4";
+    const callValueRefundAddress = "0x7a0C61EdD8b5c0c5C1437AEb571d7DDbF8022Be4";
+    const arbHalfDecayPoint = 1000;
+    const arbSetHalfDecayPointCalldata = iface.encodeFunctionData("setHalfDecayPoint(uint256)", [arbHalfDecayPoint]);
+    const actions = [[["uint256"], [arbHalfDecayPoint], arbComptrollerAddr, "0", arbSetHalfDecayPointCalldata]];
+    for (let i = 0; i < actions.length; i++) {
+        const action = actions[i];
+        const {target, value, signature, calldata, signCalldata} = await arbProposeParams(
+            action[0], // types
+            action[1], // params
+            action[2], // target
+            action[3], // values
+            action[4], // calldata
+            excessFeeRefundAddress,
+            callValueRefundAddress
+        );
+        targets.push(target);
+        values.push(value);
+        sigs.push(signature);
+        calldatas.push(calldata);
+        signedCalldatas.push(signCalldata);
+    }
+
+    // Actions for Optimism
+    const gasLimit = 2000000;
+
+    const opOwner = await ethers.getContractAt(OpOwnerABI, opOwnerAddr);
+
+    // set half decay
+    const opHalfDecayPoint = 100000;
+    const opSetHalfDecayPointCalldata = iface.encodeFunctionData("setHalfDecayPoint(uint256)", [opHalfDecayPoint]);
+    const executeOpSetHalfDecay = opOwner.interface.encodeFunctionData("execute(address,uint256,bytes)", [
+        opComptrollerAddr,
+        0,
+        opSetHalfDecayPointCalldata
+    ]);
+    targets.push(optimismBridgeAddress);
+    values.push(gasLimit);
+    sigs.push("sendMessage(address,bytes,uint32)");
+    calldatas.push(
+        ethers.utils.defaultAbiCoder.encode(
+            ["address", "bytes", "uint32"],
+            [opOwnerAddr, executeOpSetHalfDecay, gasLimit]
+        )
+    );
+    signedCalldatas.push(
+        iface.encodeFunctionData("sendMessage(address,bytes,uint32)", [opOwnerAddr, executeOpSetHalfDecay, gasLimit])
+    );
+
+    // set max stake
+    const maxStakeAmount = "25000000000000000000000";
+    const opSetMaxStakeAmountCalldata = iface.encodeFunctionData("setMaxStakeAmount(uint96)", [maxStakeAmount]);
+    const executeData = opOwner.interface.encodeFunctionData("execute(address,uint256,bytes)", [
+        opUserManagerAddr,
+        0,
+        opSetMaxStakeAmountCalldata
+    ]);
+    targets.push(optimismBridgeAddress);
+    values.push(gasLimit);
+    sigs.push("sendMessage(address,bytes,uint32)");
+    calldatas.push(
+        ethers.utils.defaultAbiCoder.encode(["address", "bytes", "uint32"], [opOwnerAddr, executeData, gasLimit])
+    );
+    signedCalldatas.push(
+        iface.encodeFunctionData("sendMessage(address,bytes,uint32)", [opOwnerAddr, executeData, gasLimit])
+    );
+
+    const msg = `
+UIP-016: Update Half Decay Point and Max Stake Parameters
+
+# Abstract
+
+- Set half decay point of the Mainnet Comptroller to 10,000.
+
+- Set half decay point of the Arbitrum Comptroller to 1,000.
+
+- Set half decay point of the Optimism Comptroller to 100,000.
+
+- Raise the max stake on Optimism to 50,000 DAI.
+
+# Specification
+
+- Set the half decay point of the Ethereum Mainnet Comptroller to 10,000
+
+- Set the half decay point of the Arbitrum Comptroller to 1,000
+
+- Set the half decay point of the Optimism Comptroller to 100,000
+
+- Raise the max stake on Optimism to 50,000 DAI.
+
+# Test Cases
+
+Tests and simulations can be found here: [PR](https://github.com/unioncredit/UIPs/pull/25)
+
+# Implementation
+
+For Mainnet:
+- Call [Comptroller](https://etherscan.io/address/0x216dE4089dCdD7B95BC34BdCe809669C788a9A5d).setHalfDecayPoint("10000") to set the half decay point to 10,000.
+
+For Arbitrum:
+- Call [Comptroller](https://arbiscan.io/address/0x641DD6258cb3E948121B10ee51594Dc2A8549fe1).setHalfDecayPoint("1000") to set the half decay point to 1,000.
+
+For Optimism:
+- Call [OpOwner](https://optimistic.etherscan.io/address/0x946A2C918F3D928B918C01D813644f27Bcd29D96).execute() to call [Comptroller](https://optimistic.etherscan.io/address/0x06a31efa04453C5F9C0A711Cdb96075308C9d6E3).setHalfDecayPoint("100000") to set the half decay point to 100,000.
+- Call [OpOwner](https://optimistic.etherscan.io/address/0x946A2C918F3D928B918C01D813644f27Bcd29D96).execute() to call [UserManager](https://optimistic.etherscan.io/address/0x8E195D65b9932185Fcc76dB5144534e0f3597628).setMaxStakeAmount("50000000000000000000000") to set max stake to 50,000 DAI.
+
+    `;
+
+    console.log("Proposal contents");
+    console.log({targets, values, sigs, calldatas, signedCalldatas, msg});
+
+    return {targets, values, sigs, calldatas, signedCalldatas, msg};
+}
+
+module.exports = {
+    getProposalParams
+};

--- a/proposals/016_update_decay_and_max_stake/submitProposal.js
+++ b/proposals/016_update_decay_and_max_stake/submitProposal.js
@@ -1,0 +1,46 @@
+const {ethers, getChainId, getNamedAccounts} = require("hardhat");
+
+(async () => {
+    const {deployer} = await getNamedAccounts();
+    const {getProposalParams} = require(`./proposal.js`);
+    const chainId = await getChainId();
+    console.log({chainId});
+    const addresses = require(`./addresses.js`)[await getChainId()];
+    console.log({addresses});
+
+    const UnionGovernorABI = require("../../abis/UnionGovernor.json");
+    const governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+    console.log({governor: governor.address});
+
+    const latestProposalId = await governor.latestProposalIds(deployer);
+    if (latestProposalId != 0) {
+        const proposersLatestProposalState = await governor.state(latestProposalId);
+        if (proposersLatestProposalState == 1) {
+            throw new Error("Proposer already has an active proposal");
+        } else if (proposersLatestProposalState == 0) {
+            throw new Error("Proposer already has a pending proposal");
+        }
+    }
+
+    const {targets, values, sigs, calldatas, signedCalldatas, msg} = await getProposalParams(addresses);
+
+    let myBuffer = [];
+    let buffer = new Buffer.from(msg);
+
+    for (let i = 0; i < buffer.length; i++) {
+        myBuffer.push(buffer[i]);
+    }
+
+    const proposalId = await governor["hashProposal(address[],uint256[],bytes[],bytes32)"](
+        targets,
+        values,
+        signedCalldatas,
+        ethers.utils.keccak256(myBuffer)
+    );
+
+    const deadline = await governor.proposalSnapshot(proposalId);
+    if (deadline > 0) {
+        throw new Error("Duplicated proposals");
+    }
+    await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+})();

--- a/proposals/016_update_decay_and_max_stake/test/testArbExecution.js
+++ b/proposals/016_update_decay_and_max_stake/test/testArbExecution.js
@@ -1,0 +1,43 @@
+const {ethers, getChainId, network} = require("hardhat");
+require("chai").should();
+const {parseUnits} = ethers.utils;
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+
+let defaultAccount, addresses;
+describe("Update half decay on Arbitrum", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://arb-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 175986720
+                    }
+                }
+            ]
+        });
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        [defaultAccount] = await ethers.getSigners();
+        timelockSigner = await ethers.getSigner(addresses.arbTimelockAddr);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [timelockSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: timelockSigner.address,
+            value: parseUnits("1")
+        });
+    });
+
+    it("Mock execute and validate results on arb", async () => {
+        const comptroller = await ethers.getContractAt(ComptrollerABI, addresses.arbComptrollerAddr);
+        const newHalfDecayPoint = 1000;
+        await comptroller.connect(timelockSigner).setHalfDecayPoint(newHalfDecayPoint);
+        (await comptroller.halfDecayPoint()).should.eq(newHalfDecayPoint);
+    });
+});

--- a/proposals/016_update_decay_and_max_stake/test/testOpExecution.js
+++ b/proposals/016_update_decay_and_max_stake/test/testOpExecution.js
@@ -1,0 +1,69 @@
+const {ethers, getChainId, network} = require("hardhat");
+require("chai").should();
+const {parseUnits} = ethers.utils;
+const {Interface} = require("ethers/lib/utils");
+const OpOwnerABI = require("../../../abis/OpOwner.json");
+const UserManagerABI = require("../../../abis/UserManager.json");
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+
+let defaultAccount, addresses, unionSigner, senderSigner;
+const opAdmin = "0x652AbFA76d8Adf89560f110322FC63156C5aE5c8";
+const unionUser = "0xb8150a1b6945e75d05769d685b127b41e6335bbc"; //An address with union on op
+describe("Set halfDecay and raise maxStake on Optimism", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://opt-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 105200000
+                    }
+                }
+            ]
+        });
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        [defaultAccount] = await ethers.getSigners();
+        unionSigner = await ethers.getSigner(unionUser);
+        senderSigner = await ethers.getSigner(opAdmin); //It is impossible to directly simulate ovmL2CrossDomainMessenger to initiate a call, so the admin call is simulated.
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [senderSigner.address]
+        });
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [unionSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: senderSigner.address,
+            value: parseUnits("1")
+        });
+        await defaultAccount.sendTransaction({
+            to: unionSigner.address,
+            value: parseUnits("1")
+        });
+    });
+
+    it("Mock execute and validate results on op", async () => {
+        const opOwner = await ethers.getContractAt(OpOwnerABI, addresses.opOwnerAddr);
+        const userManager = await ethers.getContractAt(UserManagerABI, addresses.opUserManagerAddr);
+        const iface = new Interface([
+            "function sendMessage(address,bytes,uint32) external",
+            "function setMaxStakeAmount(uint96) external",
+            "function setHalfDecayPoint(uint256) external"
+        ]);
+        const maxStakeAmount = "50000000000000000000000";
+        const data = iface.encodeFunctionData("setMaxStakeAmount(uint96)", [maxStakeAmount]);
+        await opOwner.connect(senderSigner).execute(addresses.opUserManagerAddr, 0, data);
+        (await userManager.maxStakeAmount()).should.eq(maxStakeAmount);
+
+        const comptroller = await ethers.getContractAt(ComptrollerABI, addresses.opComptrollerAddr);
+        const halfDecayPoint = "100000";
+        const setHalfDecayPointCalldata = iface.encodeFunctionData("setHalfDecayPoint(uint256)", [halfDecayPoint]);
+        await opOwner.connect(senderSigner).execute(addresses.opComptrollerAddr, 0, setHalfDecayPointCalldata);
+        (await comptroller.halfDecayPoint()).should.eq(halfDecayPoint);
+    });
+});

--- a/proposals/016_update_decay_and_max_stake/test/testProposal.js
+++ b/proposals/016_update_decay_and_max_stake/test/testProposal.js
@@ -1,0 +1,100 @@
+const {ethers, getChainId, network} = require("hardhat");
+const {expect} = require("chai");
+require("chai").should();
+
+const {parseUnits} = ethers.utils;
+const {waitNBlocks, increaseTime} = require("../../../utils");
+const {getProposalParams} = require("../proposal.js");
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+const UnionGovernorABI = require("../../../abis/UnionGovernor.json");
+const UnionTokenABI = require("../../../abis/UnionToken.json");
+const unionUser = "0x0fb99055fcdd69b711f6076be07b386aa2718bc6"; //An address with union
+
+let defaultAccount, governor, unionToken, addresses;
+
+const voteProposal = async governor => {
+    let res;
+    const proposalId = await governor.latestProposalIds(defaultAccount.address);
+
+    const votingDelay = await governor.votingDelay();
+    await waitNBlocks(parseInt(votingDelay) + 10);
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("1");
+
+    await governor.castVote(proposalId, 1);
+    const votingPeriod = await governor.votingPeriod();
+    await waitNBlocks(parseInt(votingPeriod));
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("4"); // Vote succeeded
+
+    console.log(`Queueing proposal Id: ${proposalId}`);
+
+    await governor["queue(uint256)"](proposalId);
+
+    await increaseTime(7 * 24 * 60 * 60);
+
+    res = await governor.getActions(proposalId);
+    console.log(res.toString());
+
+    console.log(`Executing proposal Id: ${proposalId}`);
+
+    await governor["execute(uint256)"](proposalId, {
+        value: parseUnits("1")
+    });
+};
+
+describe("Update half decay on mainnet", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 19125000
+                    }
+                }
+            ]
+        });
+
+        [defaultAccount] = await ethers.getSigners();
+        unionSigner = await ethers.getSigner(unionUser);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [unionSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: unionSigner.address,
+            value: parseUnits("10")
+        });
+
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+        unionToken = await ethers.getContractAt(UnionTokenABI, addresses.unionTokenAddress);
+        await unionToken.connect(unionSigner).delegate(defaultAccount.address);
+    });
+
+    it("Submit proposal", async () => {
+        console.log({addresses});
+
+        const {targets, values, sigs, calldatas, msg} = await getProposalParams(addresses);
+        await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+    });
+
+    it("Cast votes", async () => {
+        await voteProposal(governor);
+    });
+
+    it("Validate results", async () => {
+        const comptroller = await ethers.getContractAt(ComptrollerABI, addresses.comptrollerAddr);
+        const halfDecayPoint = await comptroller.halfDecayPoint();
+        console.log({halfDecayPoint});
+        halfDecayPoint.should.eq(10000);
+    });
+});


### PR DESCRIPTION
# Abstract

- Set half decay point of the Mainnet Comptroller to 10,000.

- Set half decay point of the Arbitrum Comptroller to 1,000.

- Set half decay point of the Optimism Comptroller to 100,000.

- Raise the max stake on Optimism to 50,000 DAI.

# Specification

- Set the half decay point of the Ethereum Mainnet Comptroller to 10,000

- Set the half decay point of the Arbitrum Comptroller to 1,000

- Set the half decay point of the Optimism Comptroller to 100,000

- Raise the max stake on Optimism to 50,000 DAI.

# Test Cases

Tests and simulations can be found here: [PR](https://github.com/unioncredit/UIPs/pull/25)

# Implementation

For Mainnet:
- Call [Comptroller](https://etherscan.io/address/0x216dE4089dCdD7B95BC34BdCe809669C788a9A5d).setHalfDecayPoint("10000") to set the half decay point to 10,000.

For Arbitrum:
- Call [Comptroller](https://arbiscan.io/address/0x641DD6258cb3E948121B10ee51594Dc2A8549fe1).setHalfDecayPoint("1000") to set the half decay point to 1,000.

For Optimism:
- Call [OpOwner](https://optimistic.etherscan.io/address/0x946A2C918F3D928B918C01D813644f27Bcd29D96).execute() to call [Comptroller](https://optimistic.etherscan.io/address/0x06a31efa04453C5F9C0A711Cdb96075308C9d6E3).setHalfDecayPoint("100000") to set the half decay point to 100,000.
- Call [OpOwner](https://optimistic.etherscan.io/address/0x946A2C918F3D928B918C01D813644f27Bcd29D96).execute() to call [UserManager](https://optimistic.etherscan.io/address/0x8E195D65b9932185Fcc76dB5144534e0f3597628).setMaxStakeAmount("50000000000000000000000") to set max stake to 50,000 DAI.
