### PR TITLE
UIP-017: Drip UNION to Base

### DIFF
--- a/proposals/017_drip_to_base/addresses.js
+++ b/proposals/017_drip_to_base/addresses.js
@@ -1,0 +1,20 @@
+const addresses = require("../../utils/addresses.js");
+
+Object.keys(addresses).map(networkID => {
+    switch (networkID) {
+        case "1":
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddress: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                baseConnectorAddress: "0x08447c9a86efe321fc3c54b8cddb7d5d516ce121"
+            });
+            break;
+        case "31337":
+            addresses[networkID] = Object.assign(addresses[networkID], {
+                treasuryAddress: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
+                baseConnectorAddress: "0x08447c9a86efe321fc3c54b8cddb7d5d516ce121"
+            });
+            break;
+    }
+});
+
+module.exports = addresses;

--- a/proposals/017_drip_to_base/addresses.js
+++ b/proposals/017_drip_to_base/addresses.js
@@ -5,13 +5,19 @@ Object.keys(addresses).map(networkID => {
         case "1":
             addresses[networkID] = Object.assign(addresses[networkID], {
                 treasuryAddress: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
-                baseConnectorAddress: "0x08447c9a86efe321fc3c54b8cddb7d5d516ce121"
+                baseConnectorAddress: "0x08447c9a86efe321fc3c54b8cddb7d5d516ce121",
+                baseOwnerAddr: "0x20473Af81162B3E79F0333A2d8D64C88a71B88e8",
+                baseComptrollerAddr: "0x37C092D275E48e3c9001059D9B7d55802CbDbE04",
+                baseBridgeAddress: "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa"
             });
             break;
         case "31337":
             addresses[networkID] = Object.assign(addresses[networkID], {
                 treasuryAddress: "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9",
-                baseConnectorAddress: "0x08447c9a86efe321fc3c54b8cddb7d5d516ce121"
+                baseConnectorAddress: "0x08447c9a86efe321fc3c54b8cddb7d5d516ce121",
+                baseOwnerAddr: "0x20473Af81162B3E79F0333A2d8D64C88a71B88e8",
+                baseComptrollerAddr: "0x37C092D275E48e3c9001059D9B7d55802CbDbE04",
+                baseBridgeAddress: "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa"
             });
             break;
     }

--- a/proposals/017_drip_to_base/proposal.js
+++ b/proposals/017_drip_to_base/proposal.js
@@ -33,7 +33,7 @@ async function getProposalParams(addresses) {
         treasury.interface.encodeFunctionData("addSchedule(uint256,uint256,address,uint256)", newScheduleParams)
     ];
 
-    // For Optimism
+    // For Base
 
     const gasLimit = 2000000;
 
@@ -66,7 +66,7 @@ async function getProposalParams(addresses) {
     );
 
     const msg = `
-UIP-017: Drip UNION to Base comptroller
+UIP-017: Drip UNION to Base
 
 ## Abstract
 In order to support Union on Base, UNION token will need to be distributed to participants. The L1 treasury will drip UNION token to the Base comptroller. An intermediary contract (BaseConnector) is added to connect L1 treasury to the Union Base comptroller.
@@ -75,7 +75,7 @@ In order to support Union on Base, UNION token will need to be distributed to pa
 Protocol participants will need to be able to claim UNION on the Base Network. Therefore, the Union protocol comptroller on the Base network needs to have UNION continuously dripped over.
 
 ## Specification
-- Set half decay point of the Optimism Comptroller to 100,000.
+- Set half decay point of the Base Comptroller to 100,000.
 - Add OpConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2,628,000 UNION tokens, which will last for one year at the current Ethereum block minting rate (12 seconds per block)
 
 ## Rationale
@@ -97,7 +97,7 @@ On Mainnet
     - target address: [BaseConnector](https://etherscan.io/address/0x307ED81138cA91637E432DbaBaC6E3A42699032a)
     - total amount: 2,628,000
 
-On Optimism:
+On Base:
 
 - Call [OpOwner](https://basescan.org/address/0x20473Af81162B3E79F0333A2d8D64C88a71B88e8).execute() to call [Comptroller](https://basescan.org/address/0x37C092D275E48e3c9001059D9B7d55802CbDbE04).setHalfDecayPoint("100000") to set the half decay point to 100,000.
 `;

--- a/proposals/017_drip_to_base/proposal.js
+++ b/proposals/017_drip_to_base/proposal.js
@@ -1,29 +1,69 @@
 const {ethers} = require("hardhat");
+const {Interface} = require("ethers/lib/utils");
+const OpOwnerABI = require("../../abis/OpOwner.json");
+const TreasuryABI = require("../../abis/Treasury.json");
 
 async function getProposalParams(addresses) {
-    const {treasuryAddress, baseConnectorAddress} = addresses;
+    const {treasuryAddress, baseConnectorAddress, baseOwnerAddr, baseComptrollerAddr, baseBridgeAddress} = addresses;
 
-    if (!treasuryAddress || !baseConnectorAddress) {
+    if (!(treasuryAddress && baseConnectorAddress && baseOwnerAddr && baseComptrollerAddr && baseBridgeAddress)) {
         throw new Error("address error");
     }
 
     const parseUnits = ethers.utils.parseUnits;
 
+    // For Mainnet
+
+    const treasury = await ethers.getContractAt(TreasuryABI, treasuryAddress);
+
     const targets = [treasuryAddress];
     const values = ["0"];
     const currBlock = await ethers.provider.getBlock("latest");
     const sigs = ["addSchedule(uint256,uint256,address,uint256)"];
-    const calldatas = [
-        ethers.utils.defaultAbiCoder.encode(
-            ["uint256", "uint256", "address", "uint256"],
-            [
-                currBlock.number, // drip start block
-                parseUnits("1"), // drip rate, in wei
-                baseConnectorAddress, // target address
-                parseUnits("2400000") // 1 union per block for 1 year
-            ]
-        )
+    const newScheduleParams = [
+        currBlock.number, // drip start block
+        parseUnits("1"), // drip rate, in wei
+        baseConnectorAddress, // target address
+        parseUnits("2628000") // 1 union per block for 1 year
     ];
+    const calldatas = [
+        ethers.utils.defaultAbiCoder.encode(["uint256", "uint256", "address", "uint256"], newScheduleParams)
+    ];
+    const signedCalldatas = [
+        treasury.interface.encodeFunctionData("addSchedule(uint256,uint256,address,uint256)", newScheduleParams)
+    ];
+
+    // For Optimism
+
+    const gasLimit = 2000000;
+
+    const opOwner = await ethers.getContractAt(OpOwnerABI, baseOwnerAddr);
+
+    // set half decay
+    const iface = new Interface([
+        "function sendMessage(address,bytes,uint32) external",
+        "function setHalfDecayPoint(uint256) external"
+    ]);
+
+    const opHalfDecayPoint = 100000;
+    const opSetHalfDecayPointCalldata = iface.encodeFunctionData("setHalfDecayPoint(uint256)", [opHalfDecayPoint]);
+    const executeOpSetHalfDecay = opOwner.interface.encodeFunctionData("execute(address,uint256,bytes)", [
+        baseComptrollerAddr,
+        0,
+        opSetHalfDecayPointCalldata
+    ]);
+    targets.push(baseBridgeAddress);
+    values.push(gasLimit);
+    sigs.push("sendMessage(address,bytes,uint32)");
+    calldatas.push(
+        ethers.utils.defaultAbiCoder.encode(
+            ["address", "bytes", "uint32"],
+            [baseOwnerAddr, executeOpSetHalfDecay, gasLimit]
+        )
+    );
+    signedCalldatas.push(
+        iface.encodeFunctionData("sendMessage(address,bytes,uint32)", [baseOwnerAddr, executeOpSetHalfDecay, gasLimit])
+    );
 
     const msg = `
 UIP-017: Drip UNION to Base comptroller
@@ -35,7 +75,8 @@ In order to support Union on Base, UNION token will need to be distributed to pa
 Protocol participants will need to be able to claim UNION on the Base Network. Therefore, the Union protocol comptroller on the Base network needs to have UNION continuously dripped over.
 
 ## Specification
-Add OpConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2.4M UNION tokens, which will last for 1 year at the current Ethereum block minting rate (13.14 seconds per block)
+- Set half decay point of the Optimism Comptroller to 100,000.
+- Add OpConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2,628,000 UNION tokens, which will last for one year at the current Ethereum block minting rate (12 seconds per block)
 
 ## Rationale
 Adding a treasury on L2 was considered, but there was no identifiable upside for going this route. Adding a comptroller provided the same benefits with lower effort.
@@ -44,34 +85,22 @@ Adding a treasury on L2 was considered, but there was no identifiable upside for
 No issues with backwards compatibility for this proposal
 
 ## Test Cases
-Tests and simulations can be found here: [Link to PR](https://github.com/unioncredit/union-v1-proposals/pull/9)
+Tests and simulations can be found here: [Link to PR](https://github.com/unioncredit/union-v1-proposals/pull/26)
 
 ## Implementation
-Call the function 'addSchedule(uint256,uint256,address,uint256)' of the Treasury contract ([0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9#code)) with the following parameters:
-- drip start block: the block when the proposal is created
-- drip rate: 1 UNION per block
-- target address: BaseConnector ([0x307ED81138cA91637E432DbaBaC6E3A42699032a](https://etherscan.io/address/0x307ED81138cA91637E432DbaBaC6E3A42699032a))
-- total amount: 2.4M UNION
-- PR link: https://github.com/unioncredit/union-v1-proposals/pull/9
 
-## Security Considerations
-- BaseConnector contract should work correctly to bridge any wrapped UNION on its balance to the Base comptroller.
-- Any wrapped UNION in BaseConnector cannot be sent to any addresses other than the Base bridge.
-- Wrapped UNION in BaseConnector can be withdrawn by the owner in case of emergency (by calling 'claimTokens(address recipient)')
+On Mainnet
 
+- Call [Treasury](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9).addSchedule('uint256',uint256,address,uint256) with the following parameters:
+    - drip start block: the block when the proposal is created
+    - drip rate: 1 UNION per block
+    - target address: [BaseConnector](https://etherscan.io/address/0x307ED81138cA91637E432DbaBaC6E3A42699032a)
+    - total amount: 2,628,000
+
+On Optimism:
+
+- Call [OpOwner](https://basescan.org/address/0x20473Af81162B3E79F0333A2d8D64C88a71B88e8).execute() to call [Comptroller](https://basescan.org/address/0x37C092D275E48e3c9001059D9B7d55802CbDbE04).setHalfDecayPoint("100000") to set the half decay point to 100,000.
 `;
-    const TreasuryABI = require("../../abis/Treasury.json");
-    const iface = new ethers.utils.Interface(TreasuryABI);
-    const signedCalldatas = [];
-
-    signedCalldatas.push(
-        iface.encodeFunctionData(sigs[0], [
-            currBlock.number, // drip start block
-            parseUnits("1"), // drip rate, in wei
-            baseConnectorAddress, // target address
-            parseUnits("2400000") // 1 union per block for 1 year
-        ])
-    );
 
     console.log("Proposal contents");
     console.log({targets, values, sigs, calldatas, signedCalldatas, msg});

--- a/proposals/017_drip_to_base/proposal.js
+++ b/proposals/017_drip_to_base/proposal.js
@@ -76,7 +76,7 @@ Protocol participants will need to be able to claim UNION on the Base Network. T
 
 ## Specification
 - Set half decay point of the Base Comptroller to 100,000.
-- Add OpConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2,628,000 UNION tokens, which will last for one year at the current Ethereum block minting rate (12 seconds per block)
+- Add BaseConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2,628,000 UNION tokens, which will last for one year at the current Ethereum block minting rate (12 seconds per block)
 
 ## Rationale
 Adding a treasury on L2 was considered, but there was no identifiable upside for going this route. Adding a comptroller provided the same benefits with lower effort.

--- a/proposals/017_drip_to_base/proposal.js
+++ b/proposals/017_drip_to_base/proposal.js
@@ -1,0 +1,84 @@
+const {ethers} = require("hardhat");
+
+async function getProposalParams(addresses) {
+    const {treasuryAddress, baseConnectorAddress} = addresses;
+
+    if (!treasuryAddress || !baseConnectorAddress) {
+        throw new Error("address error");
+    }
+
+    const parseUnits = ethers.utils.parseUnits;
+
+    const targets = [treasuryAddress];
+    const values = ["0"];
+    const currBlock = await ethers.provider.getBlock("latest");
+    const sigs = ["addSchedule(uint256,uint256,address,uint256)"];
+    const calldatas = [
+        ethers.utils.defaultAbiCoder.encode(
+            ["uint256", "uint256", "address", "uint256"],
+            [
+                currBlock.number, // drip start block
+                parseUnits("1"), // drip rate, in wei
+                baseConnectorAddress, // target address
+                parseUnits("2400000") // 1 union per block for 1 year
+            ]
+        )
+    ];
+
+    const msg = `
+UIP-017: Drip UNION to Base comptroller
+
+## Abstract
+In order to support Union on Base, UNION token will need to be distributed to participants. The L1 treasury will drip UNION token to the Base comptroller. An intermediary contract (BaseConnector) is added to connect L1 treasury to the Union Base comptroller.
+
+## Motivation
+Protocol participants will need to be able to claim UNION on the Base Network. Therefore, the Union protocol comptroller on the Base network needs to have UNION continuously dripped over.
+
+## Specification
+Add OpConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2.4M UNION tokens, which will last for 1 year at the current Ethereum block minting rate (13.14 seconds per block)
+
+## Rationale
+Adding a treasury on L2 was considered, but there was no identifiable upside for going this route. Adding a comptroller provided the same benefits with lower effort.
+
+## Backwards Compatibility
+No issues with backwards compatibility for this proposal
+
+## Test Cases
+Tests and simulations can be found here: [Link to PR](https://github.com/unioncredit/union-v1-proposals/pull/9)
+
+## Implementation
+Call the function 'addSchedule(uint256,uint256,address,uint256)' of the Treasury contract ([0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9#code)) with the following parameters:
+- drip start block: the block when the proposal is created
+- drip rate: 1 UNION per block
+- target address: BaseConnector ([0x307ED81138cA91637E432DbaBaC6E3A42699032a](https://etherscan.io/address/0x307ED81138cA91637E432DbaBaC6E3A42699032a))
+- total amount: 2.4M UNION
+- PR link: https://github.com/unioncredit/union-v1-proposals/pull/9
+
+## Security Considerations
+- BaseConnector contract should work correctly to bridge any wrapped UNION on its balance to the Base comptroller.
+- Any wrapped UNION in BaseConnector cannot be sent to any addresses other than the Base bridge.
+- Wrapped UNION in BaseConnector can be withdrawn by the owner in case of emergency (by calling 'claimTokens(address recipient)')
+
+`;
+    const TreasuryABI = require("../../abis/Treasury.json");
+    const iface = new ethers.utils.Interface(TreasuryABI);
+    const signedCalldatas = [];
+
+    signedCalldatas.push(
+        iface.encodeFunctionData(sigs[0], [
+            currBlock.number, // drip start block
+            parseUnits("1"), // drip rate, in wei
+            baseConnectorAddress, // target address
+            parseUnits("2400000") // 1 union per block for 1 year
+        ])
+    );
+
+    console.log("Proposal contents");
+    console.log({targets, values, sigs, calldatas, signedCalldatas, msg});
+
+    return {targets, values, sigs, calldatas, signedCalldatas, msg};
+}
+
+module.exports = {
+    getProposalParams
+};

--- a/proposals/017_drip_to_base/test/testBaseExecution.js
+++ b/proposals/017_drip_to_base/test/testBaseExecution.js
@@ -1,0 +1,62 @@
+const {ethers, getChainId, network} = require("hardhat");
+require("chai").should();
+const {parseUnits} = ethers.utils;
+const {Interface} = require("ethers/lib/utils");
+const OpOwnerABI = require("../../../abis/OpOwner.json");
+const UserManagerABI = require("../../../abis/UserManager.json");
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+
+let defaultAccount, addresses, senderSigner;
+const baseAdmin = "0x567e418D831969142b52228b65a88f894e2D79a8";
+describe("Set halfDecay on Base", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://base-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 22920144
+                    }
+                }
+            ]
+        });
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        [defaultAccount] = await ethers.getSigners();
+        //It is impossible to directly simulate cross-chain calls, so just sim from the admin account
+        senderSigner = await ethers.getSigner(baseAdmin);
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [senderSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: senderSigner.address,
+            value: parseUnits("1")
+        });
+    });
+
+    it("Simulate and validate results", async () => {
+        const {baseOwnerAddr, baseComptrollerAddr} = addresses;
+        console.log({baseOwnerAddr, baseComptrollerAddr});
+
+        const baseOwner = await ethers.getContractAt(OpOwnerABI, baseOwnerAddr);
+        const iface = new Interface(["function setHalfDecayPoint(uint256) external"]);
+
+        const halfDecayPoint = "100000";
+        const setHalfDecayPointCalldata = iface.encodeFunctionData("setHalfDecayPoint(uint256)", [halfDecayPoint]);
+
+        console.log({setHalfDecayPointCalldata});
+        console.log({senderSigner: senderSigner.address});
+
+        const comptroller = await ethers.getContractAt(ComptrollerABI, baseComptrollerAddr);
+
+        const currHalfDecayPoint = await comptroller.halfDecayPoint();
+        console.log({currHalfDecayPoint});
+        await baseOwner.connect(senderSigner).execute(baseComptrollerAddr, 0, setHalfDecayPointCalldata);
+
+        (await comptroller.halfDecayPoint()).should.eq(halfDecayPoint);
+    });
+});

--- a/proposals/017_drip_to_base/test/testCallTimelock.js
+++ b/proposals/017_drip_to_base/test/testCallTimelock.js
@@ -1,0 +1,91 @@
+const { ethers, getChainId, network } = require("hardhat");
+require("chai").should();
+const { parseUnits, formatBytes32String } = ethers.utils;
+const { Interface } = require("ethers/lib/utils");
+const { increaseTime } = require("../../../utils/index.js");
+
+const TimelockABI = require("../../../abis/TimelockController.json");
+
+let defaultAccount, addresses, senderSigner, propId;
+const unionAdminSafe = "0xD83b4686e434B402c2Ce92f4794536962b2BE3E8";
+const timelockAddr = "0xBBD3321f377742c4b3fe458b270c2F271d3294D8"
+const treasuryAddr = "0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9"
+describe("Add drip for Base", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 21435601
+                    }
+                }
+            ]
+        });
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        [defaultAccount] = await ethers.getSigners();
+        //It is impossible to directly simulate cross-chain calls, so just sim from the admin account
+        senderSigner = await ethers.getSigner(unionAdminSafe);
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [senderSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: senderSigner.address,
+            value: parseUnits("1")
+        });
+    });
+
+    it("Simulate schedule()", async () => {
+        const { baseComptrollerAddr } = addresses;
+        // console.log({ baseComptrollerAddr });
+
+        const ifaceTreasury = new Interface(["function addSchedule(uint256,uint256,address,uint256) external"]);
+
+        const currBlock = await ethers.provider.getBlock("latest");
+        const calldatas = ifaceTreasury.encodeFunctionData("addSchedule(uint256,uint256,address,uint256)",
+            [currBlock.timestamp, parseUnits("1"), baseComptrollerAddr, parseUnits("2628000")]);
+
+        const timelock = await ethers.getContractAt(TimelockABI, timelockAddr);
+        const tx = await timelock.connect(senderSigner).schedule(treasuryAddr, 0, calldatas, formatBytes32String("0"), formatBytes32String("1"), 86400);
+        console.log({ tx });
+        const result = await tx.wait();
+        const events = result.events;
+        console.log({ events: result.events });
+        console.log({ event: events[0].args });
+
+        propId = events[0].args.id;
+
+        // console.log({ currHalfDecayPoint });
+        // await baseOwner.connect(senderSigner).execute(baseComptrollerAddr, 0, setHalfDecayPointCalldata);
+    });
+
+    it("Simulate execute()", async () => {
+        const { baseComptrollerAddr } = addresses;
+        console.log({ baseComptrollerAddr });
+
+        const ifaceTreasury = new Interface(["function addSchedule(uint256,uint256,address,uint256) external"]);
+
+        const calldatas = ifaceTreasury.encodeFunctionData("addSchedule(uint256,uint256,address,uint256)",
+            [(await ethers.provider.getBlock("latest")).timestamp, parseUnits("1"), baseComptrollerAddr, parseUnits("2628000")]);
+
+        const oldBlock = await ethers.provider.getBlock("latest");
+        // console.log({ oldBlock })
+
+        await increaseTime(24 * 60 * 60);
+
+        const newBlock = await ethers.provider.getBlock("latest");
+        // console.log({ newBlock })
+
+        const timelock = await ethers.getContractAt(TimelockABI, timelockAddr);
+
+        const isReady = await timelock.isOperationReady(propId);
+        console.log({ isReady });
+
+        await timelock.connect(senderSigner).execute(treasuryAddr, 0, calldatas, formatBytes32String("0"), formatBytes32String("1"));
+    });
+});

--- a/proposals/017_drip_to_base/test/testProposal.js
+++ b/proposals/017_drip_to_base/test/testProposal.js
@@ -1,0 +1,108 @@
+const {ethers, getChainId, network} = require("hardhat");
+const {expect} = require("chai");
+require("chai").should();
+
+const {parseUnits} = ethers.utils;
+const {waitNBlocks, increaseTime} = require("../../../utils/index.js");
+const {getProposalParams} = require("../proposal.js");
+const ComptrollerABI = require("../../../abis/Comptroller.json");
+const UnionGovernorABI = require("../../../abis/UnionGovernor.json");
+const UnionTokenABI = require("../../../abis/UnionToken.json");
+const unionUser = "0x0fb99055fcdd69b711f6076be07b386aa2718bc6"; //An address with union
+
+let defaultAccount, governor, unionToken, addresses;
+
+const voteProposal = async governor => {
+    let res;
+    const proposalId = await governor.latestProposalIds(defaultAccount.address);
+
+    const votingDelay = await governor.votingDelay();
+    await waitNBlocks(parseInt(votingDelay) + 10);
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("1");
+
+    await governor.castVote(proposalId, 1);
+    const votingPeriod = await governor.votingPeriod();
+    await waitNBlocks(parseInt(votingPeriod));
+
+    res = await governor.state(proposalId);
+    res.toString().should.eq("4"); // Vote succeeded
+
+    console.log(`Queueing proposal Id: ${proposalId}`);
+
+    await governor["queue(uint256)"](proposalId);
+
+    await increaseTime(7 * 24 * 60 * 60);
+
+    res = await governor.getActions(proposalId);
+    console.log(res.toString());
+
+    console.log(`Executing proposal Id: ${proposalId}`);
+
+    await governor["execute(uint256)"](proposalId, {
+        value: parseUnits("1")
+    });
+};
+
+describe("Drip UNION to Base comptroller", async () => {
+    before(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/" + process.env.ALCHEMY_API_KEY,
+                        blockNumber: 19125000
+                    }
+                }
+            ]
+        });
+
+        [defaultAccount] = await ethers.getSigners();
+        unionSigner = await ethers.getSigner(unionUser);
+
+        await network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [unionSigner.address]
+        });
+
+        // Send ETH to account
+        await defaultAccount.sendTransaction({
+            to: unionSigner.address,
+            value: parseUnits("10")
+        });
+
+        addresses = require(`../addresses.js`)[await getChainId()];
+
+        governor = await ethers.getContractAt(UnionGovernorABI, addresses.governorAddress);
+        unionToken = await ethers.getContractAt(UnionTokenABI, addresses.unionTokenAddress);
+        await unionToken.connect(unionSigner).delegate(defaultAccount.address);
+    });
+
+    it("Submit proposal", async () => {
+        console.log({addresses});
+
+        const {targets, values, sigs, calldatas, msg} = await getProposalParams(addresses);
+        await governor["propose(address[],uint256[],string[],bytes[],string)"](targets, values, sigs, calldatas, msg);
+    });
+
+    it("Cast votes", async () => {
+        await voteProposal(governor);
+    });
+
+    it("Validate results", async () => {
+        const connectorAddress = addresses.baseConnectorAddress;
+        const prevBalance = await unionToken.balanceOf(connectorAddress);
+        console.log(ethers.utils.formatUnits(prevBalance));
+
+        const TreasuryABI = require("../../../abis/Treasury.json");
+        const treasury = await ethers.getContractAt(TreasuryABI, addresses.treasuryAddress);
+        await treasury.drip(connectorAddress);
+
+        const newBalance = await unionToken.balanceOf(connectorAddress);
+        console.log(ethers.utils.formatUnits(newBalance));
+
+        newBalance.should.gt(prevBalance);
+    });
+});

--- a/proposals/017_drip_to_base/test/testProposal.js
+++ b/proposals/017_drip_to_base/test/testProposal.js
@@ -2,7 +2,7 @@ const {ethers, getChainId, network} = require("hardhat");
 const {expect} = require("chai");
 require("chai").should();
 
-const {parseUnits} = ethers.utils;
+const {parseUnits, formatUnits} = ethers.utils;
 const {waitNBlocks, increaseTime} = require("../../../utils/index.js");
 const {getProposalParams} = require("../proposal.js");
 const ComptrollerABI = require("../../../abis/Comptroller.json");
@@ -93,16 +93,19 @@ describe("Drip UNION to Base comptroller", async () => {
 
     it("Validate results", async () => {
         const connectorAddress = addresses.baseConnectorAddress;
-        const prevBalance = await unionToken.balanceOf(connectorAddress);
-        console.log(ethers.utils.formatUnits(prevBalance));
 
         const TreasuryABI = require("../../../abis/Treasury.json");
         const treasury = await ethers.getContractAt(TreasuryABI, addresses.treasuryAddress);
         await treasury.drip(connectorAddress);
+        const prevBalance = await unionToken.balanceOf(connectorAddress);
+        // console.log(formatUnits(prevBalance));
+
+        // drip again to make sure the dripping rate is 1 Union per block
+        await treasury.drip(connectorAddress);
 
         const newBalance = await unionToken.balanceOf(connectorAddress);
-        console.log(ethers.utils.formatUnits(newBalance));
+        // console.log(formatUnits(newBalance));
 
-        newBalance.should.gt(prevBalance);
+        newBalance.should.eq(prevBalance.add(parseUnits("1")));
     });
 });


### PR DESCRIPTION
## Abstract
In order to support Union on Base, UNION token will need to be distributed to participants. The L1 treasury will drip UNION token to the Base comptroller. An intermediary contract (BaseConnector) is added to connect L1 treasury to the Union Base comptroller.

## Motivation
Protocol participants will need to be able to claim UNION on the Base Network. Therefore, the Union protocol comptroller on the Base network needs to have UNION continuously dripped over.

## Specification
- Set half decay point of the Optimism Comptroller to 100,000.
- Add OpConnector contract to be a new dripping target of the Treasury, and set the dripping rate to be 1 UNION per block in a total amount of 2,628,000 UNION tokens, which will last for one year at the current Ethereum block minting rate (12 seconds per block)

## Rationale
Adding a treasury on L2 was considered, but there was no identifiable upside for going this route. Adding a comptroller provided the same benefits with lower effort.

## Backwards Compatibility
No issues with backwards compatibility for this proposal

## Test Cases
Tests and simulations can be found here: [Link to PR](https://github.com/unioncredit/union-v1-proposals/pull/26)

## Implementation

On Mainnet

- Call [Treasury](https://etherscan.io/address/0x6DBDe0E7e563E34A53B1130D6B779ec8eD34B4B9).addSchedule('uint256',uint256,address,uint256) with the following parameters:
    - drip start block: the block when the proposal is created
    - drip rate: 1 UNION per block
    - target address: [BaseConnector](https://etherscan.io/address/0x307ED81138cA91637E432DbaBaC6E3A42699032a)
    - total amount: 2,628,000

On Optimism:

- Call [OpOwner](https://basescan.org/address/0x20473Af81162B3E79F0333A2d8D64C88a71B88e8).execute() to call [Comptroller](https://basescan.org/address/0x37C092D275E48e3c9001059D9B7d55802CbDbE04).setHalfDecayPoint("100000") to set the half decay point to 100,000.
